### PR TITLE
Get lastFireData from Database

### DIFF
--- a/backend/CommunicationLayers/dbCommunicationLayer.js
+++ b/backend/CommunicationLayers/dbCommunicationLayer.js
@@ -50,7 +50,7 @@ dbQuery.findHistoricData = function (locationKey) {
        console.log('Connected...');
        const collection = client.db("forestcasting").collection("location_historic");
        // perform actions on the collection object
-       collection.find({"locationKey": locationKey}).limit(1)
+       collection.find({"LOCATION_KEY": locationKey}).limit(1)
        .toArray()
        .then(cursor => {
          //close the connection
@@ -65,12 +65,12 @@ dbQuery.findHistoricData = function (locationKey) {
          cursor.forEach(element => results.push(new HistoricData(
            latlng[0],
            latlng[1],
-           element["locationKey"],
+           element["LOCATION_KEY"],
            element["TOTAL_SIZE_HA_OLD"],
            element["AVERAGE_SIZE_HA_OLD"],
            element["TOTAL_DURATION_OLD"],
            element["AVERAGE_DURATION_OLD"],
-           "2017-11-01"
+           element["MOST_RECENT_DATE"]
          )))
 
           resolve(results)


### PR DESCRIPTION
### Getting Fire Date
Previously this value was hardcoded, but now the value is part of the location_historic collection in the database. 

Example Call:
`http://localhost:3100/api/analysis?lat=49.6&lng=-114.6&date=2020-01-27`

Example Response:
`{"location":[{"latitude":"49.6","longitude":"-114.6","locationKey":"49.6|-114.6","totalFireSize":26.84,"averageFireSize":0.097246377,"totalFireDuration":1002,"averageFireDuration":3.630434783,"lastFireDate":"2018-08-06"}] ... `
